### PR TITLE
Better error for auth server connection failure

### DIFF
--- a/commands/api.go
+++ b/commands/api.go
@@ -63,7 +63,7 @@ func (cmd ApiCommand) Execute([]string) error {
 
 		err = verifyAuthServerConnection(cfg, cmd.SkipTlsValidation)
 		if err != nil {
-			return errors.NewNetworkError(err)
+			return errors.NewAuthServerNetworkError(err)
 		}
 
 		err = PrintWarnings(serverUrl, cmd.SkipTlsValidation)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -9,6 +9,10 @@ func NewNetworkError(e error) error {
 	return errors.New(fmt.Sprintf("Error connecting to the targeted API: %#v. Please validate your target and retry your request.", e.Error()))
 }
 
+func NewAuthServerNetworkError(e error) error {
+	return errors.New(fmt.Sprintf("Error connecting to the auth server: %#v. Please validate your target and retry your request.", e.Error()))
+}
+
 func NewCatchAllError() error {
 	return errors.New("The targeted API was unable to perform the request. Please validate and retry your request.")
 }
@@ -24,7 +28,6 @@ func NewFileLoadError() error {
 func NewMissingGetParametersError() error {
 	return errors.New("A name or ID must be provided. Please update and retry your request.")
 }
-
 
 func NewAuthorizationError() error {
 	return errors.New("The provided username and password combination are incorrect. Please validate your input and retry your request.")


### PR DESCRIPTION
I was a bit confused when the error said ca-cert was not right. And I had forgotten to provide ca-cert for UAA. Only hint was that the error said 8443 instead of 8844 for the port. Maybe this would've saved some of my time.