### PR TITLE
Adds SOCKS5 support via https_proxy ENV var

### DIFF
--- a/client/http_client.go
+++ b/client/http_client.go
@@ -49,6 +49,7 @@ func newHttpsClient(cfg config.Config) *http.Client {
 
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	client := &http.Client{

--- a/credhub/client.go
+++ b/credhub/client.go
@@ -45,6 +45,7 @@ func httpsClient(insecureSkipVerify bool, rootCAs *x509.CertPool, cert *tls.Cert
 			Certificates:             certs,
 			RootCAs:                  rootCAs,
 		},
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	return client


### PR DESCRIPTION
Fixes #18

Re-enables using the default Go 1.9 environment variables to proxy std library calls via a SOCKS5 proxy
```
$ https_proxy=socks5://localhost:61011 credhub api -s https://10.0.0.6:8844 --ca-cert "$CREDHUB_CA" --ca-cert "$UAA_CA"
```