### PR TITLE
Fix segfault for 'credhub --version'

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/cloudfoundry-incubator/credhub-cli/config"
-	"github.com/cloudfoundry-incubator/credhub-cli/errors"
 	"github.com/cloudfoundry-incubator/credhub-cli/version"
 )
 
@@ -18,14 +17,10 @@ func PrintVersion() error {
 
 	credhubClient, err := initializeCredhubClient(cfg)
 
-	if err == nil || err.Error() != errors.NewRevokedTokenError().Error() {
-		_, err := credhubClient.FindAllPaths()
-
+	if err == nil || credhubClient != nil {
+		version, err := credhubClient.ServerVersion()
 		if err == nil {
-			version, err := credhubClient.ServerVersion()
-			if err == nil {
-				credHubServerVersion = version.String()
-			}
+			credHubServerVersion = version.String()
 		}
 	}
 

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -119,13 +119,13 @@ var _ = Describe("Version", func() {
 			config.WriteConfig(cfg)
 		})
 
-		It("returns the CLI version but not the server version", func() {
+		It("returns the CLI version and the server version", func() {
 			session := runCommand("--version")
 
 			Eventually(session).Should(Exit(0))
 			sout := string(session.Out.Contents())
 			testVersion(sout)
-			Expect(sout).To(ContainSubstring("Server Version: Not Found. Have you targeted and authenticated against a CredHub server?"))
+			Expect(sout).To(ContainSubstring("Server Version: 0.2.0"))
 		})
 	})
 

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -128,6 +128,23 @@ var _ = Describe("Version", func() {
 			Expect(sout).To(ContainSubstring("Server Version: Not Found. Have you targeted and authenticated against a CredHub server?"))
 		})
 	})
+
+	Context("when no server is targeted", func() {
+		BeforeEach(func() {
+			cfg := config.ReadConfig()
+			cfg.ApiURL = ""
+			config.WriteConfig(cfg)
+		})
+
+		It("returns the CLI version and no server version", func() {
+			session := runCommand("--version")
+
+			Eventually(session).Should(Exit(0))
+			sout := string(session.Out.Contents())
+			testVersion(sout)
+			Expect(sout).To(ContainSubstring("Server Version: Not Found. Have you targeted and authenticated against a CredHub server?"))
+		})
+	})
 })
 
 func testVersion(sout string) {


### PR DESCRIPTION
Hi folks,

I was very surprised to find such a big mistake in CredHub code (issue #29), so I started digging into it, in order to submit a fix.

The problem is that the `PrintVersion` (in `commands/version.go`) is calling `credhubClient.FindAllPaths()` in order to test if an actual CredHub server is targeted. This in the first place might not be a good idea. Imagine there is a ton of credentials and the connection is very slow... Well, I really wouldn't recommend doing that, and instead, write (or reuse) a dedicated method for knowing if a CredHub server is targeted.

Then it breaks when reaching the `Request()` method (in `credhub/request.go`) because the main `CredHub` object pointer is actually `nil`. So when dereferencing it for the `ch.Auth` field leads to a *Segmentation Fault* for a nil pointer dereference.

This is due to the `initializeCredhubClient()` call (in `commands/version.go`) returning a `NewNoApiUrlSetError` because there is no CredHub targeted. Then this error is not filtered because only the `NewRevokedTokenError` is considered problematic. The first problem here is conceptual: implementing a black-list of problematic errors (preventing the `credhubClient.ServerVersion()` to be relevant) is *not* safe. Instead, a white-list of acceptable errors is way safer. The second problem is that the `NewRevokedTokenError` is not problematic at all for fetching the server version, because the `/info` endpoint doesn't require any authentication.

So this leads to a strange situation where the condition on the `NewRevokedTokenError` just seems to be reversed. Acceptable errors should be those related to authentication.

In the end, this PR provides a failing test case that demonstrates the issue, and suggests a fix. Instead of implementing a white-list of acceptable errors when creating the CredHub client, we finally ended up just testing whether a non-`nil` client is returned. This allows returning the server version when tokens are invalid. Which is not surprising because the `/info` endpoint doesn't require any authentication. So we modified the unit test related to this case.

Don't hesitate to make feedback, comments, suggestions about this approach!

Cheers,
Benjamin