### PR TITLE
GET request shouldn't send any content-length header

### DIFF
--- a/credhub/request.go
+++ b/credhub/request.go
@@ -29,12 +29,18 @@ func (ch *CredHub) request(client requester, method string, pathStr string, quer
 	u.Path = pathStr
 	u.RawQuery = query.Encode()
 
+	var req *http.Request
+
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(method, u.String(), bytes.NewReader(jsonBody))
+	if body != nil {
+		req, err = http.NewRequest(method, u.String(), bytes.NewReader(jsonBody))
+	} else {
+		req, err = http.NewRequest(method, u.String(), nil)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Thank you for credhub!

We had a problem trying to use credhub behind a GCP https loadbalancer.

We found that a GET request issued by the cli sends a content-length header with a value of 4 and it shouldn't. The code was not testing if the body was nil, and json.Marshal(body) returns then a non empty string.
This breaks when using a GCP https load balancer in front of credhub for example as it doesn't respect the RFC.

PR from: @ahelal and myself 