### PR TITLE
Enable HTTP Keepalive's to reduce number of TLS handshakes

### DIFF
--- a/credhub/auth/uaa/client.go
+++ b/credhub/auth/uaa/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -79,6 +80,7 @@ func (u *Client) Metadata() (*Metadata, error) {
 		return nil, err
 	}
 	defer response.Body.Close()
+	defer io.Copy(ioutil.Discard, response.Body)
 
 	if response.StatusCode != 200 {
 		return nil, errors.New("unable to fetch metadata successfully")
@@ -167,6 +169,7 @@ func (u *Client) tokenGrantRequest(headers url.Values) (token, error) {
 	}
 
 	defer response.Body.Close()
+	defer io.Copy(ioutil.Discard, response.Body)
 
 	decoder := json.NewDecoder(response.Body)
 

--- a/credhub/bulk_regenerate.go
+++ b/credhub/bulk_regenerate.go
@@ -2,6 +2,8 @@ package credhub
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials"
@@ -22,6 +24,7 @@ func (ch *CredHub) BulkRegenerate(signedBy string) (credentials.BulkRegenerateRe
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&creds)
 

--- a/credhub/client.go
+++ b/credhub/client.go
@@ -55,8 +55,9 @@ func httpsClient(insecureSkipVerify bool, rootCAs *x509.CertPool, cert *tls.Cert
 			Certificates:             certs,
 			RootCAs:                  rootCAs,
 		},
-		Proxy: http.ProxyFromEnvironment,
-		Dial: dialer,
+		Proxy:               http.ProxyFromEnvironment,
+		Dial:                dialer,
+		MaxIdleConnsPerHost: 100,
 	}
 
 	return client

--- a/credhub/generate.go
+++ b/credhub/generate.go
@@ -2,6 +2,8 @@ package credhub
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials"
@@ -75,6 +77,7 @@ func (ch *CredHub) generateCredential(name, credType string, gen interface{}, ov
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	dec := json.NewDecoder(resp.Body)
 
 	if err := ch.checkForServerError(resp); err != nil {

--- a/credhub/get.go
+++ b/credhub/get.go
@@ -3,6 +3,8 @@ package credhub
 import (
 	"encoding/json"
 	"errors"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -114,6 +116,7 @@ func (ch *CredHub) makeCredentialGetRequest(query url.Values, cred interface{}) 
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	dec := json.NewDecoder(resp.Body)
 
 	response := make(map[string][]json.RawMessage)
@@ -142,6 +145,7 @@ func (ch *CredHub) makeCredentialGetByIdRequest(id string, cred *credentials.Cre
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	dec := json.NewDecoder(resp.Body)
 
 	if err := dec.Decode(cred); err != nil {
@@ -167,6 +171,7 @@ func (ch *CredHub) makeMultiCredentialGetRequest(query url.Values) ([]credential
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	dec := json.NewDecoder(resp.Body)
 
 	response := make(map[string][]credentials.Credential)

--- a/credhub/info.go
+++ b/credhub/info.go
@@ -3,6 +3,8 @@ package credhub
 import (
 	"encoding/json"
 	"errors"
+	"io"
+	"io/ioutil"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/server"
 )
@@ -16,6 +18,7 @@ func (ch *CredHub) Info() (*server.Info, error) {
 	}
 
 	defer response.Body.Close()
+	defer io.Copy(ioutil.Discard, response.Body)
 
 	info := &server.Info{}
 	decoder := json.NewDecoder(response.Body)

--- a/credhub/permissions.go
+++ b/credhub/permissions.go
@@ -1,6 +1,8 @@
 package credhub
 
 import (
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"net/url"
@@ -26,6 +28,7 @@ func (ch *CredHub) GetPermissions(credName string) ([]permissions.Permission, er
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	var response permissionsResponse
 
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {

--- a/credhub/regenerate.go
+++ b/credhub/regenerate.go
@@ -2,6 +2,8 @@ package credhub
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials"
@@ -24,6 +26,7 @@ func (ch *CredHub) Regenerate(name string) (credentials.Credential, error) {
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&cred)
 

--- a/credhub/request.go
+++ b/credhub/request.go
@@ -3,6 +3,8 @@ package credhub
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -65,6 +67,7 @@ func (ch *CredHub) request(client requester, method string, pathStr string, quer
 func (ch *CredHub) checkForServerError(resp *http.Response) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer resp.Body.Close()
+		defer io.Copy(ioutil.Discard, resp.Body)
 		dec := json.NewDecoder(resp.Body)
 
 		respErr := &Error{}

--- a/credhub/server_version.go
+++ b/credhub/server_version.go
@@ -2,6 +2,8 @@ package credhub
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/server"
 	"github.com/hashicorp/go-version"
@@ -29,6 +31,7 @@ func (ch *CredHub) getVersion() (string, error) {
 	}
 
 	defer response.Body.Close()
+	defer io.Copy(ioutil.Discard, response.Body)
 
 	versionData := &server.VersionData{}
 	decoder := json.NewDecoder(response.Body)

--- a/credhub/set.go
+++ b/credhub/set.go
@@ -2,6 +2,8 @@ package credhub
 
 import (
 	"encoding/json"
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials"
@@ -92,6 +94,7 @@ func (ch *CredHub) setCredential(name, credType string, value interface{}, mode 
 	}
 
 	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body)
 	dec := json.NewDecoder(resp.Body)
 	return dec.Decode(cred)
 }


### PR DESCRIPTION
We found that when using Credhub with Concourse, there was a massive spike in
CPU usage. We profiled ATC (Concourse component that interacts with Credhub) and
found that >90% of samples were in TLS handshake methods. We did not profile
credhub, but presumably it was much the same.

This commit ensures HTTP response body's are read to completion, which is
required for net/http to reuse the connection and avoid a costly TLS handshake.
It also increases the maximum number of idle HTTP connections to 100, from the
default of 2, which is required to work around limitations in net/http:

https://github.com/golang/go/issues/13801

Signed-off-by: Ife Runsewe <ife.runsewe@engineerbetter.com>