### PR TITLE
Use a canonical import path for code.cloudfoundry.org

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main
+package main // import "code.cloudfoundry.org/credhub-cli"
 
 import (
 	"fmt"


### PR DESCRIPTION
This will help detect errors when users mistakenly `go get` the github.com/cloudfoundry-incubator import path.

See: https://golang.org/doc/go1.4#canonicalimports

I ran into an issue with the following workflow:
```
$ go get -u -d github.com/cloudfoundry-incubator/credhub-cli
$ cd "$(go env GOPATH)/src/github.com/cloudfoundry-incubator/credhub-cli"
$ go test ./...
# github.com/cloudfoundry-incubator/credhub-cli/commands_test
commands/bulk_regenerate_test.go:83:5: undefined: commands.HaveFlag
commands/find_test.go:37:5: undefined: commands.HaveFlag
commands/find_test.go:38:5: undefined: commands.HaveFlag
commands/generate_test.go:528:5: undefined: commands.HaveFlag
commands/generate_test.go:529:5: undefined: commands.HaveFlag
commands/generate_test.go:530:5: undefined: commands.HaveFlag
commands/generate_test.go:531:5: undefined: commands.HaveFlag
commands/generate_test.go:532:5: undefined: commands.HaveFlag
commands/generate_test.go:533:5: undefined: commands.HaveFlag
commands/generate_test.go:534:5: undefined: commands.HaveFlag
commands/generate_test.go:534:5: too many errors
```

It took me quite a while to figure out why this was occurring.  The `go get` actually fetched the `credhub-cli` repo _twice_: once under `src/github.com` and a second time under `src/code.cloudfoundry.org`.  The `_test.go` file was not linked into the test binary because the import paths didn't match.

With this change, the workflow above would have issued a warning:

```
code in directory [...] expects import "code.cloudfoundry.org/credhub-cli"
```