### PR TITLE
OAuth flow errors are getting swallowed

### DIFF
--- a/credhub/auth/oauth.go
+++ b/credhub/auth/oauth.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -149,7 +150,7 @@ func (a *OAuthStrategy) requestToken() error {
 	}
 
 	if err != nil {
-		return errors.New("Your token has expired and could not be refreshed. Please log in again to continue.")
+		return fmt.Errorf(fmt.Sprintf("Error getting token. Your token may have expired and could not be refreshed. Please try logging in again. [%s]", err.Error()))
 	}
 
 	a.SetTokens(accessToken, refreshToken)

--- a/credhub/auth/oauth_test.go
+++ b/credhub/auth/oauth_test.go
@@ -151,7 +151,7 @@ var _ = Describe("OAuthStrategy", func() {
 					request, _ := http.NewRequest("GET", "https://some-endpoint.com/path/", nil)
 
 					_, err := oauth.Do(request)
-					Expect(err).To(MatchError("Your token has expired and could not be refreshed. Please log in again to continue."))
+					Expect(err).To(MatchError("Error getting token. Your token may have expired and could not be refreshed. Please try logging in again. [failed to login]"))
 				})
 			})
 
@@ -363,7 +363,7 @@ var _ = Describe("OAuthStrategy", func() {
 					}
 
 					err := uaa.Refresh()
-					Expect(err).To(MatchError("Your token has expired and could not be refreshed. Please log in again to continue."))
+					Expect(err).To(MatchError("Error getting token. Your token may have expired and could not be refreshed. Please try logging in again. [password grant error]"))
 				})
 			})
 
@@ -398,7 +398,7 @@ var _ = Describe("OAuthStrategy", func() {
 
 						err := uaa.Refresh()
 
-						Expect(err).To(MatchError("Your token has expired and could not be refreshed. Please log in again to continue."))
+						Expect(err).To(MatchError("Error getting token. Your token may have expired and could not be refreshed. Please try logging in again. [client credentials grant failed]"))
 
 					})
 				})
@@ -495,7 +495,7 @@ var _ = Describe("OAuthStrategy", func() {
 
 					err := uaa.Refresh()
 
-					Expect(err).To(MatchError("Your token has expired and could not be refreshed. Please log in again to continue."))
+					Expect(err).To(MatchError("Error getting token. Your token may have expired and could not be refreshed. Please try logging in again. [client credentials grant failed]"))
 
 				})
 			})


### PR DESCRIPTION
`requestToken` was obscuring the underlying failure and reporting any error as an expired token. This isn't accurate; quite a few other things could cause an error at that part of the auth flow.