### PR TITLE
Export certificate 'ca_name' of signed certificates

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -59,6 +59,21 @@ func getAllCredentialsForPath(path string) ([]credentials.Credential, error) {
 			return nil, err
 		}
 
+		if credential.Type == "certificate" {
+			certMetadata, err := credhubClient.GetCertificateMetadataByName(credential.Name)
+
+			if err != nil {
+				return nil, err
+			}
+			signedBy := certMetadata.SignedBy
+
+			if signedBy != "" && signedBy != credential.Name {
+				if cert, ok := credential.Value.(map[string]interface{}); ok {
+					cert["ca"] = signedBy
+					credential.Value = cert
+				}
+			}
+		}
 		credentials[i] = credential
 	}
 

--- a/credhub/certificates.go
+++ b/credhub/certificates.go
@@ -6,16 +6,31 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"code.cloudfoundry.org/credhub-cli/credhub/credentials"
 )
 
 func (ch *CredHub) GetAllCertificatesMetadata() ([]credentials.CertificateMetadata, error) {
-	return ch.makeGetAllCertificatesRequest()
+	query := url.Values{}
+	
+	return ch.makeGetCertificatesRequest(query)
 }
 
-func (ch *CredHub) makeGetAllCertificatesRequest() ([]credentials.CertificateMetadata, error) {
-	resp, err := ch.Request(http.MethodGet, "/api/v1/certificates/", nil, nil, true)
+func (ch *CredHub) GetCertificateMetadataByName(name string) (credentials.CertificateMetadata, error) {
+	query := url.Values{}
+	query.Set("name", name)
+
+	certs, err := ch.makeGetCertificatesRequest(query)
+	if err != nil {
+		return credentials.CertificateMetadata{}, err
+	}
+
+	return certs[0], nil
+}
+
+func (ch *CredHub) makeGetCertificatesRequest(query url.Values) ([]credentials.CertificateMetadata, error) {
+	resp, err := ch.Request(http.MethodGet, "/api/v1/certificates/", query, nil, true)
 
 	if err != nil {
 		return nil, err

--- a/credhub/certificates_test.go
+++ b/credhub/certificates_test.go
@@ -27,6 +27,19 @@ var _ = Describe("Certificates", func() {
 
 	})
 
+	It("requests the certificates by name", func() {
+		dummy := &DummyAuth{Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+		}}
+
+		ch, _ := New("https://example.com", Auth(dummy.Builder()))
+		_, _ = ch.GetCertificateMetadataByName("/example-certificate")
+		url := dummy.Request.URL.String()
+		Expect(url).To(Equal("https://example.com/api/v1/certificates/?name=%2Fexample-certificate"))
+		Expect(dummy.Request.Method).To(Equal(http.MethodGet))
+	})
+
 	Context("getting certificate metadata", func() {
 		Describe("when there is data returned", func() {
 			It("marshals it properly", func() {


### PR DESCRIPTION
- It exports 'ca_name' instead of the 'ca' value if the certificate is not
a ca.
- It exports 'ca' value if the certificate is a ca.

PR https://github.com/cloudfoundry-incubator/credhub-cli/issues/84