### PR TITLE
Bug Fix: PANIC during Debug

### DIFF
--- a/credhub/request.go
+++ b/credhub/request.go
@@ -58,6 +58,9 @@ func (ch *CredHub) request(client requester, method string, pathStr string, quer
 
 	resp, err := client.Do(req)
 	if err != nil {
+		if os.Getenv("CREDHUB_DEBUG") == "true" {
+			fmt.Println(fmt.Sprintf("[DEBUG] %s: %v", "An error occurred during the data request.", err))
+		}
 		return resp, err
 	}
 

--- a/credhub/request.go
+++ b/credhub/request.go
@@ -57,13 +57,12 @@ func (ch *CredHub) request(client requester, method string, pathStr string, quer
 	}
 
 	resp, err := client.Do(req)
+	if err != nil {
+		return resp, err
+	}
 
 	if os.Getenv("CREDHUB_DEBUG") == "true" {
 		dumpResponse(resp)
-	}
-
-	if err != nil {
-		return resp, err
 	}
 
 	if checkServerErr {


### PR DESCRIPTION
Reopening pull request: https://github.com/cloudfoundry-incubator/credhub-cli/pull/100

The credhub debug panics when the response is `nil`, this is due to the position of the dumpResponse i.e earlier when the API request response has an error, the sequence says to dump the response first which is invalid (since the response is nil or doesn't have any memory address)

```
2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR 2020/07/07 13:27:40 http: panic serving 10.255.198.163:55202: runtime error: invalid memory address or nil pointer dereference
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR goroutine 30 [running]:
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR net/http.(*conn).serve.func1(0xc000020aa0)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/packages/golang-1.13-linux/25f15f4c67baa9e4bfe9e6a3268ee1eb67ce7004/src/net/http/server.go:1767 +0x139
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR panic(0x8f6280, 0xd92480)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/packages/golang-1.13-linux/25f15f4c67baa9e4bfe9e6a3268ee1eb67ce7004/src/runtime/panic.go:679 +0x1b2
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR net/http/httputil.DumpResponse(0x0, 0x994f01, 0xd, 0xc0000a7678, 0x1, 0x8, 0xc000106710)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/packages/golang-1.13-linux/25f15f4c67baa9e4bfe9e6a3268ee1eb67ce7004/src/net/http/httputil/dump.go:284 +0x43
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/credhub-cli/credhub.dumpResponse(0x0)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/credhub-cli/credhub/request.go:113 +0x45
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/credhub-cli/credhub.(*CredHub).request(0xc00013e380, 0x7fa83a408470,0xc000020d20, 0x98e7ff, 0x3, 0x99463b, 0xc, 0xc000106ab8, 0x0, 0x0, ...)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/credhub-cli/credhub/request.go:62 +0x477
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/credhub-cli/credhub.(*CredHub).Request(...)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/credhub-cli/credhub/request.go:25
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/credhub-cli/credhub.(*CredHub).makeCredentialGetRequest(0xc00013e380, 0xc000106ab8, 0x8a93c0, 0xc0000b62d0, 0x0, 0x0)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/credhub-cli/credhub/get.go:112 +0xd1
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/credhub-cli/credhub.(*CredHub).getCurrentCredential(0xc00013e380, 0xc0000249f0,
0x2f, 0x8a93c0, 0xc0000b62d0, 0xd942c0, 0x97c140)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/credhub-cli/credhub/get.go:108 +0x1c5
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/credhub-cli/credhub.(*CredHub).GetLatestJSON(...)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/credhub-cli/credhub/get.go:57
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/service-broker-store/brokerstore/credhub_shims.(*CredhubShim).GetLatestJSON(0xc000190068, 0xc0000249f0, 0x2f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/service-broker-store/brokerstore/credhub_shims/credhub_shims.go:77 +0xd0
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR code.cloudfoundry.org/service-broker-store/brokerstore.(*CredhubStore).RetrieveInstanceDetails(0xc00018c6c0, 0xc0000960da, 0x24, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
 2020-07-07T08:27:40.86-0500 [APP/PROC/WEB/0] ERR /var/vcap/data/compile/nfsbroker/src/code.cloudfoundry.org/service-broker-store/brokerstore/credhub_store.go:71 +0x24c
```
This patch changes the order i.e to return the error if there is a error and dump if there is no error. Also added a debug line to print the error for easier debug since the [service broker store](https://github.com/cloudfoundry/service-broker-store/blob/8ce20271b626105189aaf2768e5c82fdff6807c4/brokerstore/store.go#L98) completely looses the error inflight making it harder to debug
