### PR TITLE
Add CLI support for client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository contains a Go client library that can be used independently of t
 
 ### Usage:
 
-CredHub CLI can be used to manage credentials stored in a CredHub server. You must first target the CredHub server using the `api` command. Once targeted, you must login with either user or client credentials. Future commands will be sent to the targeted server. For additional information on how to perform CLI operations, you may review the examples shown [here][1] or review the help menus with the commands `credhub --help` and `credhub <command> --help`.
+CredHub CLI can be used to manage credentials stored in a CredHub server. You must first target the CredHub server using the `api` command. Once targeted, you must login with either user credentials, client credentials, or client certificate. Future commands will be sent to the targeted server. For additional information on how to perform CLI operations, you may review the examples shown [here][1] or review the help menus with the commands `credhub --help` and `credhub <command> --help`.
 
 #### Debug Mode:
 

--- a/commands/import.go
+++ b/commands/import.go
@@ -117,7 +117,7 @@ func (c *ImportCommand) setCredentials(bulkImport models.CredentialBulkImport) e
 
 func isAuthenticationError(err error) bool {
 	return reflect.DeepEqual(err, errors.NewNoApiUrlSetError()) ||
-		reflect.DeepEqual(err, errors.NewRevokedTokenError()) ||
+		reflect.DeepEqual(err, errors.NewUnauthenticatedError()) ||
 		reflect.DeepEqual(err, errors.NewRefreshError())
 }
 

--- a/config/client_from_config.go
+++ b/config/client_from_config.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"code.cloudfoundry.org/credhub-cli/credhub"
+	"code.cloudfoundry.org/credhub-cli/credhub/auth"
+)
+
+func NewCredhubClientFromConfig(cfg Config) (*credhub.CredHub, error) {
+	var loginOption credhub.Option
+	if cfg.ClientCertPath == "" {
+		useClientCredentials := true
+		clientId := cfg.ClientID
+		clientSecret := cfg.ClientSecret
+		if clientId == "" {
+			useClientCredentials = false
+			clientId = AuthClient
+			clientSecret = AuthPassword
+		}
+		loginOption = credhub.Auth(auth.Uaa(
+			clientId,
+			clientSecret,
+			"",
+			"",
+			cfg.AccessToken,
+			cfg.RefreshToken,
+			useClientCredentials,
+		))
+	} else {
+		loginOption = credhub.ClientCert(
+			cfg.ClientCertPath,
+			cfg.ClientKeyPath,
+		)
+	}
+
+	client, err := credhub.New(cfg.ApiURL,
+		credhub.AuthURL(cfg.AuthURL),
+		credhub.CaCerts(cfg.CaCerts...),
+		credhub.SkipTLSValidation(cfg.InsecureSkipVerify),
+		loginOption,
+		credhub.ServerVersion(cfg.ServerVersion),
+		credhub.SetHttpTimeout(cfg.HttpTimeout),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}

--- a/config/client_from_config_test.go
+++ b/config/client_from_config_test.go
@@ -1,0 +1,67 @@
+// +build !windows
+
+package config_test
+
+import (
+	"net/http"
+
+	"code.cloudfoundry.org/credhub-cli/config"
+	"code.cloudfoundry.org/credhub-cli/credhub/auth"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NewCredhubClientFromConfig", func() {
+	var cfg config.Config
+
+	BeforeEach(func() {
+		cfg = config.Config{
+			ConfigWithoutSecrets: config.ConfigWithoutSecrets{
+				ApiURL:  "http://api.example.com",
+				AuthURL: "http://auth.example.com",
+			},
+		}
+	})
+
+	Context("when client credentials are supplied", func() {
+		It("uses the OAuth auth strategy", func() {
+			cfg.ClientID = "a-client-id"
+			cfg.ClientSecret = "a-client-secret"
+
+			client, err := config.NewCredhubClientFromConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Auth).To(BeAssignableToTypeOf(&auth.OAuthStrategy{}))
+		})
+	})
+
+	Context("when non-client credentials are supplied", func() {
+		It("uses the OAuth auth strategy", func() {
+			client, err := config.NewCredhubClientFromConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Auth).To(BeAssignableToTypeOf(&auth.OAuthStrategy{}))
+		})
+	})
+
+	Context("when a client TLS certificate is supplied", func() {
+		BeforeEach(func() {
+			cfg.ApiURL = "https://api.example.com"
+			cfg.ClientCertPath = "../credhub/fixtures/auth-tls-cert.pem"
+			cfg.ClientKeyPath = "../credhub/fixtures/auth-tls-key.pem"
+		})
+
+		It("does not use the OAuth auth strategy", func() {
+			client, err := config.NewCredhubClientFromConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client.Auth).NotTo(BeAssignableToTypeOf(&auth.OAuthStrategy{}))
+		})
+
+		It("configures the client certificate on HTTPS requests", func() {
+			client, err := config.NewCredhubClientFromConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			transport := client.Client().Transport.(*http.Transport)
+			tlsConfig := transport.TLSClientConfig
+			Expect(len(tlsConfig.Certificates)).To(Equal(1))
+		})
+	})
+})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strconv"
 	"time"
 
 	"code.cloudfoundry.org/credhub-cli/config"
@@ -79,7 +80,7 @@ var _ = Describe("Config", func() {
 	})
 
 	Describe("HttpTimeout", func() {
-		It("write the http timeout to disk", func() {
+		It("writes the http timeout to disk", func() {
 			someClientID := "someClientID"
 			someClientSecret := "someClientSecret"
 			timeout := 60 * time.Second
@@ -104,7 +105,7 @@ var _ = Describe("Config", func() {
 
 			configFile, err := ioutil.ReadFile(path.Join(os.Getenv("HOME"), ".credhub", "config.json"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(configFile)).NotTo(ContainSubstring(string(60 * time.Second)))
+			Expect(string(configFile)).To(ContainSubstring(strconv.Itoa(int(60 * time.Second))))
 		})
 	})
 

--- a/config/validation.go
+++ b/config/validation.go
@@ -6,8 +6,8 @@ func ValidateConfig(c Config) error {
 	err := ValidateConfigApi(c)
 	if err != nil {
 		return err
-	} else if (c.AccessToken == "" || c.AccessToken == "revoked") && c.ClientID == "" {
-		return errors.NewRevokedTokenError()
+	} else if (c.AccessToken == "" || c.AccessToken == "revoked") && c.ClientID == "" && c.ClientCertPath == "" {
+		return errors.NewUnauthenticatedError()
 	}
 
 	return nil

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -42,4 +42,13 @@ var _ = Describe("Config validation", func() {
 		Expect(config.ValidateConfig(cfg)).To(Equal(errors.New("You are not currently authenticated. Please log in to continue.")))
 
 	})
+
+	It("accepts an empty token if a client certificate is set", func() {
+		cfg := config.Config{}
+		cfg.ApiURL = "http://api.example.com"
+		cfg.ClientCertPath = "client.crt"
+
+		Expect(config.ValidateConfig(cfg)).To(BeNil())
+
+	})
 })

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -21,7 +21,7 @@ func NewFailedToImportError() error {
 	return errors.New("One or more credentials failed to import.")
 }
 
-func NewRevokedTokenError() error {
+func NewUnauthenticatedError() error {
 	return errors.New("You are not currently authenticated. Please log in to continue.")
 }
 

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 			if err := config.ValidateConfig(cfg); err != nil {
 				return err
 			}
-			client, err := cfg.Client()
+			client, err := config.NewCredhubClientFromConfig(cfg)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"code.cloudfoundry.org/credhub-cli/commands"
 	"code.cloudfoundry.org/credhub-cli/config"
 	"code.cloudfoundry.org/credhub-cli/credhub"
-	"code.cloudfoundry.org/credhub-cli/credhub/auth"
 	"github.com/jessevdk/go-flags"
 )
 
@@ -46,30 +45,7 @@ func main() {
 			if err := config.ValidateConfig(cfg); err != nil {
 				return err
 			}
-			clientId := cfg.ClientID
-			clientSecret := cfg.ClientSecret
-			useClientCredentials := true
-			if clientId == "" {
-				clientId = config.AuthClient
-				clientSecret = config.AuthPassword
-				useClientCredentials = false
-			}
-			client, err := credhub.New(cfg.ApiURL,
-				credhub.AuthURL(cfg.AuthURL),
-				credhub.CaCerts(cfg.CaCerts...),
-				credhub.SkipTLSValidation(cfg.InsecureSkipVerify),
-				credhub.Auth(auth.Uaa(
-					clientId,
-					clientSecret,
-					"",
-					"",
-					cfg.AccessToken,
-					cfg.RefreshToken,
-					useClientCredentials,
-				)),
-				credhub.ServerVersion(cfg.ServerVersion),
-				credhub.SetHttpTimeout(cfg.HttpTimeout),
-			)
+			client, err := cfg.Client()
 			if err != nil {
 				return err
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ var _ = Describe("main", func() {
 			}
 		})
 	})
+
 	Context("when extra arguments are provided", func() {
 		It("prints help and exits", func() {
 			cmd := exec.Command(commandPath, "version", "this")
@@ -36,6 +37,7 @@ var _ = Describe("main", func() {
 			Expect(session.Err).To(Say("Usage:"))
 		})
 	})
+
 	Context("when a prepended / is used in the argument", func() {
 		BeforeEach(func() {
 			if runtime.GOOS != "windows" {


### PR DESCRIPTION
Hi CredHub. This is a small enhancement that will be very valuable to some CredHub app secrets work that I'm doing.

## What

This PR allows specifying a client certificate to use to authenticate with CredHub. I added two new environment variables for this, `CREDHUB_CLIENT_CERT_PATH` and `CREDHUB_CLIENT_KEY_PATH`. The `credhub` library inside this codebase already supported client certificates so this PR is mostly refactoring and new tests.

## Why

We want to use the [CF Instance Identity](https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html) CredHub roles (named `mtls-app:APP_GUID`) to control access to secrets. There is already a [credhub-buildpack](https://github.com/andy-paine/credhub-buildpack) for flexibly pulling secrets from CredHub. That buildpack relies on this CLI, and so without this PR it can't make use of those Instance Identity roles.

## Testing

I've added tests for things that have changed or are new.

I've checked that with this PR I can get and set credentials in CredHub using the CF instance identity client certificates.

Some of the "when a new API is provided" tests in `commands` were already failing for me before this work.