### PR TITLE
Omits empty metadata field when exporting credentials

### DIFF
--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -211,14 +211,12 @@ var _ = Describe("Export", func() {
     ca_name: /path/to/cert_ca
     certificate: some_cert
     private_key: private_key
-  metadata: {}
 - name: /path/to/cert_ca
   type: certificate
   value:
     ca: some_ca
     certificate: some_cert
-    private_key: private_key
-  metadata: {}`
+    private_key: private_key`
 
 			server.AppendHandlers(
 				CombineHandlers(

--- a/models/credential_bulk_export.go
+++ b/models/credential_bulk_export.go
@@ -11,7 +11,7 @@ type exportCredential struct {
 	Name     string
 	Type     string
 	Value    interface{}
-	Metadata interface{}
+	Metadata credentials.Metadata `json:",omitempty" yaml:",omitempty"`
 }
 
 type exportCredentials struct {


### PR DESCRIPTION
- this change is consistent with the behavior of `credhub get`
- to fix "server does not support credential metadata" error when
exporting creds from & importing back into an old version of credhub
server that does not support metadata

[#174536502]
[Issue #104]