### PR TITLE
Display duration_overridden flag in the generate/regenerate output when not null

### DIFF
--- a/credhub/credentials/types.go
+++ b/credhub/credentials/types.go
@@ -15,7 +15,7 @@ type Base struct {
 	Type               string   `json:"type" yaml:"type"`
 	Metadata           Metadata `json:"metadata" yaml:"metadata"`
 	VersionCreatedAt   string   `json:"version_created_at" yaml:"version_created_at"`
-	DurationOverridden bool     `json:"duration_overridden" yaml:"duration_overridden"`
+	DurationOverridden bool     `json:"duration_overridden,omitempty" yaml:"duration_overridden,omitempty"`
 }
 
 // Arbitrary metadata for credentials

--- a/credhub/credentials/types.go
+++ b/credhub/credentials/types.go
@@ -10,11 +10,12 @@ import (
 
 // Base fields of a credential
 type Base struct {
-	Id               string   `json:"id" yaml:"id"`
-	Name             string   `json:"name" yaml:"name"`
-	Type             string   `json:"type" yaml:"type"`
-	Metadata         Metadata `json:"metadata" yaml:"metadata"`
-	VersionCreatedAt string   `json:"version_created_at" yaml:"version_created_at"`
+	Id                 string   `json:"id" yaml:"id"`
+	Name               string   `json:"name" yaml:"name"`
+	Type               string   `json:"type" yaml:"type"`
+	Metadata           Metadata `json:"metadata" yaml:"metadata"`
+	VersionCreatedAt   string   `json:"version_created_at" yaml:"version_created_at"`
+	DurationOverridden bool     `json:"duration_overridden" yaml:"duration_overridden"`
 }
 
 // Arbitrary metadata for credentials
@@ -44,18 +45,20 @@ func (c Credential) MarshalJSON() ([]byte, error) {
 
 func (c Credential) convertToOutput() (interface{}, error) {
 	result := struct {
-		Id               string      `json:"id" yaml:"id"`
-		Name             string      `json:"name" yaml:"name"`
-		Type             string      `json:"type" yaml:"type"`
-		Value            interface{} `json:"value"`
-		Metadata         Metadata    `json:"metadata" yaml:"metadata,omitempty"`
-		VersionCreatedAt string      `json:"version_created_at" yaml:"version_created_at"`
+		Id                 string      `json:"id" yaml:"id"`
+		Name               string      `json:"name" yaml:"name"`
+		Type               string      `json:"type" yaml:"type"`
+		Value              interface{} `json:"value"`
+		Metadata           Metadata    `json:"metadata" yaml:"metadata,omitempty"`
+		VersionCreatedAt   string      `json:"version_created_at" yaml:"version_created_at"`
+		DurationOverridden bool        `json:"duration_overridden,omitempty" yaml:"duration_overridden,omitempty"`
 	}{
-		Id:               c.Id,
-		Name:             c.Name,
-		Type:             c.Type,
-		Metadata:         c.Metadata,
-		VersionCreatedAt: c.VersionCreatedAt,
+		Id:                 c.Id,
+		Name:               c.Name,
+		Type:               c.Type,
+		Metadata:           c.Metadata,
+		VersionCreatedAt:   c.VersionCreatedAt,
+		DurationOverridden: c.DurationOverridden,
 	}
 
 	_, ok := c.Value.(string)

--- a/credhub/credentials/types_test.go
+++ b/credhub/credentials/types_test.go
@@ -14,7 +14,67 @@ import (
 
 var _ = Describe("Types", func() {
 	Describe("Certificate", func() {
-		Specify("when decoding and encoding", func() {
+		Specify("when decoding and encoding with duration_overridden in the output", func() {
+			var cred Certificate
+
+			credJSON := `{
+	"id": "some-id",
+	"name": "/example-certificate",
+	"type": "certificate",
+	"duration_overridden": true,
+	"value": {
+		"ca": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+		"certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+		"private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+	},
+	"metadata": {"some":"metadata"},
+	"version_created_at": "2017-01-01T04:07:18Z"
+}`
+			credYaml := `id: some-id
+name: /example-certificate
+type: certificate
+duration_overridden: true
+value:
+  ca: |-
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  certificate: |-
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  private_key: |-
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
+metadata:
+  some: metadata
+version_created_at: 2017-01-01T04:07:18Z`
+
+			err := json.Unmarshal([]byte(credJSON), &cred)
+
+			Expect(err).To(BeNil())
+
+			Expect(cred.Id).To(Equal("some-id"))
+			Expect(cred.Name).To(Equal("/example-certificate"))
+			Expect(cred.Type).To(Equal("certificate"))
+			Expect(cred.DurationOverridden).To(Equal(true))
+			Expect(cred.Metadata).To(Equal(Metadata{"some": "metadata"}))
+			Expect(cred.Value.Ca).To(Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"))
+			Expect(cred.Value.Certificate).To(Equal("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"))
+			Expect(cred.Value.PrivateKey).To(Equal("-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"))
+			Expect(cred.VersionCreatedAt).To(Equal("2017-01-01T04:07:18Z"))
+
+			jsonOutput, err := json.Marshal(cred)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(jsonOutput).To(MatchJSON(credJSON))
+
+			yamlOutput, err := yaml.Marshal(cred)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(yamlOutput).To(MatchYAML(credYaml))
+		})
+
+		Specify("when decoding and encoding with NO duration_overridden in the output", func() {
 			var cred Certificate
 
 			credJSON := `{
@@ -121,6 +181,7 @@ version_created_at: '2017-01-05T01:01:01Z'`
 			Expect(err).NotTo(HaveOccurred())
 			Expect(yamlOutput).To(MatchYAML(credYaml))
 		})
+
 	})
 
 	Describe("Password", func() {


### PR DESCRIPTION
- Depends on the changes in https://github.com/cloudfoundry-incubator/credhub/pull/201
- For more information, refer this issue: https://github.com/pivotal/credhub-release/issues/60

cc @pabloarodas @ystros